### PR TITLE
关于图形化界面提示line14出现问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ __author__ = 'Jerry'
 import datetime
 from tkinter import *
 from seckill.seckill_taobao import ChromeDrive
-
+import time
 
 
 def run_killer(txt, txt2):

--- a/main.py
+++ b/main.py
@@ -30,7 +30,8 @@ def main():
     start_time = StringVar()
     txt = Entry(win, textvariable = start_time, width = 18)
     txt.grid(column = 1, row = 0)
-    start_time.set(str(datetime.datetime.now()))
+    # start_time.set(str(datetime.datetime.now()))#带时间戳的
+    start_time.set(time.strftime('%Y-%m-%d %H:%M:%S',time.localtime(time.time())))#不带时间戳的  此处为修改的版本
 
     lbl2 = Label(win, text = "支付密码：", width = 8, height = 2)
     lbl2.grid(column = 0, row = 1)

--- a/seckill/seckill_taobao.py
+++ b/seckill/seckill_taobao.py
@@ -64,7 +64,7 @@ class ChromeDrive:
         except WebDriverException:
             try:
                 driver = webdriver.Chrome(executable_path=self.chrome_path, chrome_options=self.build_chrome_options())
-
+                        #提示找不到驱动就去网上找自己版本的驱动，放自己的chromedriver文件位置   executable_path="/Users/nobb/code/taobao_seckill/chromedriver"
             except WebDriverException:
                 raise
         return driver


### PR DESCRIPTION
line14 报错主要是是因为图形化窗口时间戳过长导致的
在窗口处删除后面这段即可
或者导入time包 把
```
start_time.set(str(datetime.datetime.now()))
```
替换为
```
start_time.set(time.strftime('%Y-%m-%d %H:%M:%S',time.localtime(time.time())))#不带时间戳的
```
但是这个操作可能回影响这个速度，因为不会精确到很精细的时间，再说了这个程序运行起来大家都说3秒，也不差这一回，瞬间秒杀的就不要想了

还有就是找不到driver的驱动，晚上找自己版本的，最新的都有
```
driver = webdriver.Chrome(executable_path="/Users/nobb/code/taobao_seckill/chromedriver", chrome_options=self.build_chrome_options())


executable_path=""    很明显就是你自己的路径，win的可能是c\\dowloda\\driver  双斜杠
```

