### PR TITLE
优化时间输入框的时间格式

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def main():
     start_time = StringVar()
     txt = Entry(win, textvariable = start_time, width = 18)
     txt.grid(column = 1, row = 0)
-    start_time.set(str(datetime.datetime.now()))
+    start_time.set(str(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
 
     lbl2 = Label(win, text = "支付密码：", width = 8, height = 2)
     lbl2.grid(column = 0, row = 1)


### PR DESCRIPTION
【优化】程序启动后时间框显示问题
程序启动之后时间框会显示毫秒，在main.py的第33行添加时间格式化语句